### PR TITLE
[th] Update countries.ts - Thailand altSpellings

### DIFF
--- a/backend/database/data/countries.ts
+++ b/backend/database/data/countries.ts
@@ -13945,8 +13945,8 @@ export default [
     capital: 'Bangkok',
     altSpellings: [
       'TH',
-      'Prathet',
-      'Thai',
+      'Prathet Thai',
+      'ประเทศไทย',
       'Kingdom of Thailand',
       'ราชอาณาจักรไทย',
       'Ratcha Anachak Thai',


### PR DESCRIPTION
- Fix: "Prathet" and "Thai" should be in the same word
- Add: "ประเทศไทย" (Prathet Thai)